### PR TITLE
Missing Reference, Wrong Reference Folder, Changed Extra Heat Calc, Added Meteor Impact FX to beam

### DIFF
--- a/CrashLanding/CrashLanding.csproj
+++ b/CrashLanding/CrashLanding.csproj
@@ -33,25 +33,25 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\..\..\..\..\steam\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed\0Harmony.dll</HintPath>
+      <HintPath>..\oni-libs\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\steam\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\oni-libs\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>..\..\..\..\..\steam\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>..\oni-libs\Assembly-CSharp-firstpass.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\steam\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>..\oni-libs\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\..\steam\steamapps\common\OxygenNotIncluded\OxygenNotIncluded_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\oni-libs\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/MeteorDefenseLaser/MeteorDefenseLaser.cs
+++ b/MeteorDefenseLaser/MeteorDefenseLaser.cs
@@ -452,7 +452,7 @@ namespace rlane
             if (CameraController.Instance.IsAudibleSound(position, sound))
             {
                 EventInstance instance = KFMOD.BeginOneShot(sound, position);
-                instance.setParameterByName("userVolume_SFX", KPlayerPrefs.GetFloat("Volume_SFX"));
+                instance.setParameterByName2("userVolume_SFX", KPlayerPrefs.GetFloat("Volume_SFX"));
                 KFMOD.EndOneShot(instance);
             }
             var fx_position = position;

--- a/MeteorDefenseLaser/MeteorDefenseLaser.cs
+++ b/MeteorDefenseLaser/MeteorDefenseLaser.cs
@@ -478,7 +478,18 @@ namespace rlane
             var cell = Grid.PosToCell(position);
             if (SafeCell(cell))
             {
-                Game.Instance.SpawnFX(SpawnFXHashes.BuildingSpark, position, 0f);
+                // if comet type is iron or rock, show appropriate FX. The lil' dust ones just asplode straight away so no FX for them (Comet Name is IronComet or RockComet for all comets, FX names apparently changed since initial naming and don't match up with comet names anymore)
+                //Debug.Log("Comet Name: " + comet.GetComponent<PrimaryElement>().name);
+                if (comet.GetComponent<PrimaryElement>().name is "IronComet")
+                {
+                    Game.Instance.SpawnFX(SpawnFXHashes.MeteorImpactMetal, position, 0f);
+
+                } else if (comet.GetComponent<PrimaryElement>().name is "RockComet") 
+                {
+                    Game.Instance.SpawnFX(SpawnFXHashes.MeteorImpactDirt, position, 0f);
+                }
+                // Alternatively or additionally, show the original spawkly effect used (might make a config option)
+                // Game.Instance.SpawnFX(SpawnFXHashes.BuildingSpark, position, 0f);
             }
         }
 

--- a/MeteorDefenseLaser/MeteorDefenseLaser.cs
+++ b/MeteorDefenseLaser/MeteorDefenseLaser.cs
@@ -360,8 +360,8 @@ namespace rlane
             var heat_energy = laser_heat_production * dt;
             if (primary_element.Mass > 100)
             {
-                // HACK: Rock comets are hundreds of times more massive than iron comets. Even with the electricity to heat multiplier we couldn't affect them. Boost heat production by 100x.
-                heat_energy *= 100;
+                // HACK: Rock comets are hundreds of times more massive than iron comets. Even with the electricity to heat multiplier we couldn't affect them. Apply heat based on mass (Rock Comets are between 4000kg and 7200kg)
+                heat_energy *= primary_element.Mass / 10;
             }
             // Use half the heat to ablate the meteor and the rest to warm it.
             var burn_heat_energy = 0.5f * heat_energy;
@@ -372,6 +372,14 @@ namespace rlane
             if (primary_element.Temperature > primary_element.Element.highTemp || primary_element.Mass <= mass_removed)
             {
                 ShowExplosion(comet);
+                // Drop Resources! :D - If there is a better way to do this, I'm not surprised but I sure couldn't find it (outseeker)
+                PrimaryElement component = comet.GetComponent<PrimaryElement>();
+                component.Mass = primary_element.Mass;
+                component.Temperature = primary_element.Temperature;
+                Element element = component.Element;
+                Substance substance = element.substance;
+                GameObject go = substance.SpawnResource(comet.transform.GetPosition(), component.Mass, component.Temperature, byte.MaxValue, 0);
+                //Debug.Log("Spawned resource from destroyed comet");
                 Util.KDestroyGameObject(comet.gameObject);
                 kills += 1;
             }

--- a/MeteorDefenseLaser/MeteorDefenseLaser.cs
+++ b/MeteorDefenseLaser/MeteorDefenseLaser.cs
@@ -452,7 +452,7 @@ namespace rlane
             if (CameraController.Instance.IsAudibleSound(position, sound))
             {
                 EventInstance instance = KFMOD.BeginOneShot(sound, position);
-                instance.setParameterByName2("userVolume_SFX", KPlayerPrefs.GetFloat("Volume_SFX"));
+                instance.setParameterByName("userVolume_SFX", KPlayerPrefs.GetFloat("Volume_SFX"));
                 KFMOD.EndOneShot(instance);
             }
             var fx_position = position;

--- a/MeteorDefenseLaser/MeteorDefenseLaser.csproj
+++ b/MeteorDefenseLaser/MeteorDefenseLaser.csproj
@@ -41,6 +41,9 @@
     <Reference Include="Assembly-CSharp-firstpass">
       <HintPath>..\oni-libs\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
+    <Reference Include="FMODUnity">
+      <HintPath>..\oni-libs\FMODUnity.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEngine">
       <HintPath>..\oni-libs\UnityEngine.dll</HintPath>
     </Reference>


### PR DESCRIPTION
- Updated the CrashLanding project file which had steamapps\common\blah instead of ..\oni-libs\ for the Reference locations

MeteorDefenceLaser:
- Updated Extra Heat Energy calculation to do more to larger masses, based on mass (first number I tried was divide by 10, seems good- was having problems with large meteors managing to get through and destroy defences regularly)
- Added Resource dropping from comet element, mass (and heat for the moment, 1000+ degrees after being heated- might want to add some config options)
- Added Comet Impact FX to the beam FX when it connects with a meteor based on meteor type
- Added Reference to FMODUnity as it was complaining about a missing reference and couldn't compile

Completely your call if you want to integrate any of this, it's what I'd already done at the point we updated it to not crash :)
Not sure the code is as efficient as it should be since I've never coded for this game before, but it all works.